### PR TITLE
fix(plugin): implement content negotiation the right way [DNS-840]

### DIFF
--- a/cmd/plugin/init/dnsprovider/dnsprovider.go
+++ b/cmd/plugin/init/dnsprovider/dnsprovider.go
@@ -22,17 +22,17 @@ func Init(config configuration.Config) provider.Provider {
 		domainFilter = endpoint.NewDomainFilterWithExclusions(config.DomainFilter, config.ExcludeDomains)
 	}
 
-	log.Infof("Creating IONOS core provider with parameters Domain filter: %s , Exclude domain filter: %s, Regexp domain filter: %s, Regexp domain filter exclusion: %s, Dry run: %t",
+	log.Infof("Creating IONOS core prov with parameters Domain filter: %s , Exclude domain filter: %s, Regexp domain filter: %s, Regexp domain filter exclusion: %s, Dry run: %t",
 		strings.Join(config.DomainFilter, ","),
 		strings.Join(config.ExcludeDomains, ","),
 		config.RegexDomainFilter,
 		config.RegexDomainExclusion,
 		config.DryRun)
 
-	provider, err := ionoscore.NewProvider(domainFilter, config.DryRun)
+	prov, err := ionoscore.NewProvider(domainFilter, config.DryRun)
 	if err != nil {
-		log.Fatalf("Failed to initialize IonosCore provider: %v", err)
+		log.Fatalf("Failed to initialize IonosCore prov: %v", err)
 	}
 
-	return provider
+	return prov
 }

--- a/cmd/plugin/init/dnsprovider/dnsprovider.go
+++ b/cmd/plugin/init/dnsprovider/dnsprovider.go
@@ -22,7 +22,7 @@ func Init(config configuration.Config) provider.Provider {
 		domainFilter = endpoint.NewDomainFilterWithExclusions(config.DomainFilter, config.ExcludeDomains)
 	}
 
-	log.Infof("Creating IONOS core prov with parameters Domain filter: %s , Exclude domain filter: %s, Regexp domain filter: %s, Regexp domain filter exclusion: %s, Dry run: %t",
+	log.Infof("Creating IONOS core provider with parameters Domain filter: %s , Exclude domain filter: %s, Regexp domain filter: %s, Regexp domain filter exclusion: %s, Dry run: %t",
 		strings.Join(config.DomainFilter, ","),
 		strings.Join(config.ExcludeDomains, ","),
 		config.RegexDomainFilter,
@@ -31,7 +31,7 @@ func Init(config configuration.Config) provider.Provider {
 
 	prov, err := ionoscore.NewProvider(domainFilter, config.DryRun)
 	if err != nil {
-		log.Fatalf("Failed to initialize IonosCore prov: %v", err)
+		log.Fatalf("Failed to initialize IonosCore provider: %v", err)
 	}
 
 	return prov

--- a/cmd/plugin/init/dnsprovider/dnsprovider_test.go
+++ b/cmd/plugin/init/dnsprovider/dnsprovider_test.go
@@ -23,7 +23,6 @@ func TestInit(t *testing.T) {
 		},
 	}
 
-	// run test cases
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			for k, v := range tc.env {

--- a/cmd/plugin/init/server/server.go
+++ b/cmd/plugin/init/server/server.go
@@ -23,9 +23,6 @@ import (
 func Init(config configuration.Config, p *plugin.Plugin) *http.Server {
 	r := chi.NewRouter()
 	r.Use(plugin.Health)
-	r.Use(p.AcceptType)
-	r.Use(p.ContentType)
-	r.Get("/", p.Negotiate)
 	r.Get("/records", p.Records)
 	r.Post("/records", p.ApplyChanges)
 	r.Post("/propertyvaluesequals", p.PropertyValuesEquals)

--- a/cmd/plugin/init/server/server_test.go
+++ b/cmd/plugin/init/server/server_test.go
@@ -137,7 +137,7 @@ func TestApplyChanges(t *testing.T) {
         }
     ]
 }`,
-			expectedStatusCode:      http.StatusOK,
+			expectedStatusCode:      http.StatusNoContent,
 			expectedResponseHeaders: map[string]string{},
 			expectedBody:            "",
 			expectedChanges: &plan.Changes{

--- a/cmd/plugin/init/server/server_test.go
+++ b/cmd/plugin/init/server/server_test.go
@@ -52,37 +52,36 @@ func TestMain(m *testing.M) {
 	}
 }
 
-func TestNegotiate(t *testing.T) {
-	testCases := []testCase{
-		{
-			name:               "negotiate, happy case",
-			method:             http.MethodGet,
-			headers:            map[string]string{"Accept": "application/external.dns.plugin+json;version=1"},
-			path:               "/",
-			body:               "",
-			expectedStatusCode: http.StatusOK,
-			expectedResponseHeaders: map[string]string{
-				"Content-Type": "application/external.dns.plugin+json;version=1",
-				"Vary":         "Content-Type",
-			},
-			expectedBody: "",
-		},
-		{
-			name:                    "negotiate with unsupported version",
-			method:                  http.MethodGet,
-			headers:                 map[string]string{"Accept": "application/external.dns.plugin+json;version=2"},
-			path:                    "/",
-			body:                    "",
-			expectedStatusCode:      http.StatusUnsupportedMediaType,
-			expectedResponseHeaders: map[string]string{},
-			expectedBody:            "unsupported media type version: 'application/external.dns.plugin+json;version=2'. Supported media types are: 'application/external.dns.plugin+json;version=1'",
-		},
-	}
-	executeTestCases(t, testCases)
-}
+//func TestNegotiate(t *testing.T) {
+//	testCases := []testCase{
+//		{
+//			name:               "negotiate, happy case",
+//			method:             http.MethodGet,
+//			headers:            map[string]string{"Accept": "application/external.dns.plugin+json;version=1"},
+//			path:               "/",
+//			body:               "",
+//			expectedStatusCode: http.StatusOK,
+//			expectedResponseHeaders: map[string]string{
+//				"Content-Type": "application/external.dns.plugin+json;version=1",
+//				"Vary":         "Content-Type",
+//			},
+//			expectedBody: "",
+//		},
+//		{
+//			name:                    "negotiate with unsupported version",
+//			method:                  http.MethodGet,
+//			headers:                 map[string]string{"Accept": "application/external.dns.plugin+json;version=2"},
+//			path:                    "/",
+//			body:                    "",
+//			expectedStatusCode:      http.StatusUnsupportedMediaType,
+//			expectedResponseHeaders: map[string]string{},
+//			expectedBody:            "unsupported media type version: 'application/external.dns.plugin+json;version=2'. Supported media types are: 'application/external.dns.plugin+json;version=1'",
+//		},
+//	}
+//	executeTestCases(t, testCases)
+//}
 
 func TestRecords(t *testing.T) {
-	negotiateMediaType(t)
 	testCases := []testCase{
 		{
 			name: "happy case",
@@ -129,7 +128,7 @@ func TestRecords(t *testing.T) {
 			expectedResponseHeaders: map[string]string{
 				"Content-Type": "text/plain",
 			},
-			expectedBody: "only allows media type 'application/external.dns.plugin+json;version=1' as accept header",
+			expectedBody: "client must provide a valid versioned media type in the accept header: unsupported media type version: 'invalid'. Supported media types are: 'application/external.dns.plugin+json;version=1'",
 		},
 		{
 			name:               "backend error",
@@ -145,7 +144,6 @@ func TestRecords(t *testing.T) {
 }
 
 func TestApplyChanges(t *testing.T) {
-	negotiateMediaType(t)
 	testCases := []testCase{
 		{
 			name:   "happy case",
@@ -210,7 +208,7 @@ func TestApplyChanges(t *testing.T) {
 			expectedResponseHeaders: map[string]string{
 				"Content-Type": "text/plain",
 			},
-			expectedBody: "only allows media type 'application/external.dns.plugin+json;version=1' as content-type",
+			expectedBody: "client must provide a valid versioned media type in the content type: unsupported media type version: 'invalid'. Supported media types are: 'application/external.dns.plugin+json;version=1'",
 		},
 		{
 			name:   "invalid json",
@@ -258,7 +256,6 @@ func TestApplyChanges(t *testing.T) {
 }
 
 func TestAdjustEndpoints(t *testing.T) {
-	negotiateMediaType(t)
 	testCases := []testCase{
 		{
 			name: "happy case",
@@ -337,7 +334,7 @@ func TestAdjustEndpoints(t *testing.T) {
 			expectedResponseHeaders: map[string]string{
 				"Content-Type": "text/plain",
 			},
-			expectedBody: "only allows media type 'application/external.dns.plugin+json;version=1' as content-type",
+			expectedBody: "client must provide a valid versioned media type in the content type: unsupported media type version: 'invalid'. Supported media types are: 'application/external.dns.plugin+json;version=1'",
 		},
 		{
 			name:   "no accept header",
@@ -366,7 +363,7 @@ func TestAdjustEndpoints(t *testing.T) {
 			expectedResponseHeaders: map[string]string{
 				"Content-Type": "text/plain",
 			},
-			expectedBody: "only allows media type 'application/external.dns.plugin+json;version=1' as accept header",
+			expectedBody: "client must provide a valid versioned media type in the accept header: unsupported media type version: 'invalid'. Supported media types are: 'application/external.dns.plugin+json;version=1'",
 		},
 		{
 			name:   "invalid json",
@@ -388,7 +385,6 @@ func TestAdjustEndpoints(t *testing.T) {
 }
 
 func TestPropertyValuesEqual(t *testing.T) {
-	negotiateMediaType(t)
 	testCases := []testCase{
 		{
 			name:   "happy case",
@@ -440,7 +436,7 @@ func TestPropertyValuesEqual(t *testing.T) {
 			expectedResponseHeaders: map[string]string{
 				"Content-Type": "text/plain",
 			},
-			expectedBody: "only allows media type 'application/external.dns.plugin+json;version=1' as content-type",
+			expectedBody: "client must provide a valid versioned media type in the content type: unsupported media type version: 'invalid'. Supported media types are: 'application/external.dns.plugin+json;version=1'",
 		},
 		{
 			name:   "no accept header",
@@ -469,7 +465,7 @@ func TestPropertyValuesEqual(t *testing.T) {
 			expectedResponseHeaders: map[string]string{
 				"Content-Type": "text/plain",
 			},
-			expectedBody: "only allows media type 'application/external.dns.plugin+json;version=1' as accept header",
+			expectedBody: "client must provide a valid versioned media type in the accept header: unsupported media type version: 'invalid'. Supported media types are: 'application/external.dns.plugin+json;version=1'",
 		},
 		{
 			name:   "invalid json",
@@ -490,17 +486,17 @@ func TestPropertyValuesEqual(t *testing.T) {
 	executeTestCases(t, testCases)
 }
 
-func negotiateMediaType(t *testing.T) {
-	request, err := http.NewRequest(http.MethodGet, "http://localhost:8888/", nil)
-	if err != nil {
-		t.Error(err)
-	}
-	request.Header.Set("Accept", "application/external.dns.plugin+json;version=1")
-	_, err = http.DefaultClient.Do(request)
-	if err != nil {
-		t.Error(err)
-	}
-}
+//func negotiateMediaType(t *testing.T) {
+//	request, err := http.NewRequest(http.MethodGet, "http://localhost:8888/", nil)
+//	if err != nil {
+//		t.Error(err)
+//	}
+//	request.Header.Set("Accept", "application/external.dns.plugin+json;version=1")
+//	_, err = http.DefaultClient.Do(request)
+//	if err != nil {
+//		t.Error(err)
+//	}
+//}
 
 func executeTestCases(t *testing.T, testCases []testCase) {
 	log.SetLevel(log.DebugLevel)
@@ -536,7 +532,7 @@ func executeTestCases(t *testing.T, testCases []testCase) {
 				if err != nil {
 					t.Error(err)
 				}
-				response.Body.Close()
+				_ = response.Body.Close()
 				actualTrimmedBody := strings.TrimSpace(string(body))
 				if actualTrimmedBody != tc.expectedBody {
 					t.Errorf("expected body '%s', got '%s'", tc.expectedBody, actualTrimmedBody)

--- a/cmd/plugin/init/server/server_test.go
+++ b/cmd/plugin/init/server/server_test.go
@@ -40,7 +40,6 @@ type testCase struct {
 
 var mockProvider *MockProvider
 
-// add test main
 func TestMain(m *testing.M) {
 	mockProvider = &MockProvider{}
 	srv := Init(configuration.Init(), plugin.New(mockProvider))
@@ -51,35 +50,6 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 }
-
-//func TestNegotiate(t *testing.T) {
-//	testCases := []testCase{
-//		{
-//			name:               "negotiate, happy case",
-//			method:             http.MethodGet,
-//			headers:            map[string]string{"Accept": "application/external.dns.plugin+json;version=1"},
-//			path:               "/",
-//			body:               "",
-//			expectedStatusCode: http.StatusOK,
-//			expectedResponseHeaders: map[string]string{
-//				"Content-Type": "application/external.dns.plugin+json;version=1",
-//				"Vary":         "Content-Type",
-//			},
-//			expectedBody: "",
-//		},
-//		{
-//			name:                    "negotiate with unsupported version",
-//			method:                  http.MethodGet,
-//			headers:                 map[string]string{"Accept": "application/external.dns.plugin+json;version=2"},
-//			path:                    "/",
-//			body:                    "",
-//			expectedStatusCode:      http.StatusUnsupportedMediaType,
-//			expectedResponseHeaders: map[string]string{},
-//			expectedBody:            "unsupported media type version: 'application/external.dns.plugin+json;version=2'. Supported media types are: 'application/external.dns.plugin+json;version=1'",
-//		},
-//	}
-//	executeTestCases(t, testCases)
-//}
 
 func TestRecords(t *testing.T) {
 	testCases := []testCase{
@@ -485,18 +455,6 @@ func TestPropertyValuesEqual(t *testing.T) {
 	}
 	executeTestCases(t, testCases)
 }
-
-//func negotiateMediaType(t *testing.T) {
-//	request, err := http.NewRequest(http.MethodGet, "http://localhost:8888/", nil)
-//	if err != nil {
-//		t.Error(err)
-//	}
-//	request.Header.Set("Accept", "application/external.dns.plugin+json;version=1")
-//	_, err = http.DefaultClient.Do(request)
-//	if err != nil {
-//		t.Error(err)
-//	}
-//}
 
 func executeTestCases(t *testing.T, testCases []testCase) {
 	log.SetLevel(log.DebugLevel)

--- a/internal/ionoscore/ionoscore.go
+++ b/internal/ionoscore/ionoscore.go
@@ -24,7 +24,7 @@ type Provider struct {
 	dryRun       bool
 }
 
-// DnsService
+// DnsService interface to the dns backend, also needed for creating mocks in tests
 type DnsService interface {
 	GetZones(ctx context.Context) ([]sdk.Zone, error)
 	GetZone(ctx context.Context, zoneId string) (*sdk.CustomerZone, error)
@@ -81,13 +81,13 @@ func NewProvider(domainFilter endpoint.DomainFilter, dryRun bool) (*Provider, er
 		return nil, fmt.Errorf("provider creation failed, %v", err)
 	}
 
-	provider := &Provider{
+	prov := &Provider{
 		client:       DnsClient{client: client},
 		domainFilter: domainFilter,
 		dryRun:       dryRun,
 	}
 
-	return provider, nil
+	return prov, nil
 }
 
 // createClient creates the API DNS client
@@ -150,8 +150,8 @@ func (p *Provider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 			}
 		}
 
-		for _, endpoint := range recordSets {
-			endpoints = append(endpoints, endpoint)
+		for _, ep := range recordSets {
+			endpoints = append(endpoints, ep)
 		}
 	}
 	log.Debugf("Records() found %d endpoints: %v", len(endpoints), endpoints)

--- a/pkg/endpoint/domain_filter_test.go
+++ b/pkg/endpoint/domain_filter_test.go
@@ -405,7 +405,7 @@ func TestPrepareFiltersStripsWhitespaceAndDotSuffix(t *testing.T) {
 }
 
 func TestMatchFilterReturnsProperEmptyVal(t *testing.T) {
-	emptyFilters := []string{}
+	var emptyFilters []string
 	assert.Equal(t, true, matchFilter(emptyFilters, "somedomain.com", true))
 	assert.Equal(t, false, matchFilter(emptyFilters, "somedomain.com", false))
 }

--- a/pkg/endpoint/target_filter_test.go
+++ b/pkg/endpoint/target_filter_test.go
@@ -103,7 +103,7 @@ func TestTargetFilterMatchWithEmptyFilter(t *testing.T) {
 }
 
 func TestMatchTargetFilterReturnsProperEmptyVal(t *testing.T) {
-	emptyFilters := []string{}
+	var emptyFilters []string
 	assert.Equal(t, true, matchFilter(emptyFilters, "sometarget.com", true))
 	assert.Equal(t, false, matchFilter(emptyFilters, "sometarget.com", false))
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -176,7 +176,7 @@ func (p *Plugin) ApplyChanges(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // PropertyValuesEqualsRequest holds params for property values equals request

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -25,6 +25,8 @@ const (
 	logFieldError          = "error"
 )
 
+var mediaTypeVersion1 = mediaTypeVersion("1")
+
 type mediaType string
 
 func mediaTypeVersion(v string) mediaType {
@@ -35,11 +37,10 @@ func (m mediaType) Is(headerValue string) bool {
 	return string(m) == headerValue
 }
 
-func checkAndSetMediaTypeHeaderValue(value string) error {
+func checkAndGetMediaTypeHeaderValue(value string) (string, error) {
 	for _, v := range strings.Split(supportedMediaVersions, ",") {
 		if mediaTypeVersion(v).Is(value) {
-			currentMediaType = mediaTypeVersion(v)
-			return nil
+			return v, nil
 		}
 	}
 	supportedMediaTypesString := ""
@@ -50,17 +51,8 @@ func checkAndSetMediaTypeHeaderValue(value string) error {
 		}
 		supportedMediaTypesString += string(mediaTypeVersion(v)) + sep
 	}
-	return fmt.Errorf("unsupported media type version: '%s'. Supported media types are: '%s'", value, supportedMediaTypesString)
+	return "", fmt.Errorf("unsupported media type version: '%s'. Supported media types are: '%s'", value, supportedMediaTypesString)
 }
-
-func checkMediaTypeSet() error {
-	if len(currentMediaType) == 0 {
-		return fmt.Errorf("media type not set, please call the negotiation endpoint first")
-	}
-	return nil
-}
-
-var currentMediaType mediaType
 
 // Plugin for external dns provider
 type Plugin struct {
@@ -73,30 +65,6 @@ func New(provider provider.Provider) *Plugin {
 	return &p
 }
 
-func (p *Plugin) hasAcceptHeader(w http.ResponseWriter, r *http.Request) bool {
-	if len(r.Header.Get(acceptHeader)) == 0 {
-		w.Header().Set(contentTypeHeader, contentTypePlaintext)
-		w.WriteHeader(http.StatusNotAcceptable)
-		err := fmt.Errorf("client must provide an accept header")
-		fmt.Fprint(w, err.Error())
-		requestLog(r).WithField(logFieldError, err).Info("accept header check failed")
-		return false
-	}
-	return true
-}
-
-func (p *Plugin) hasContentHeader(w http.ResponseWriter, r *http.Request) bool {
-	if len(r.Header.Get(contentTypeHeader)) == 0 {
-		w.Header().Set(contentTypeHeader, contentTypePlaintext)
-		w.WriteHeader(http.StatusNotAcceptable)
-		err := fmt.Errorf("client must provide a content type")
-		fmt.Fprint(w, err.Error())
-		requestLog(r).WithField(logFieldError, err).Info("content type header check failed")
-		return false
-	}
-	return true
-}
-
 func Health(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == healthPath {
@@ -107,116 +75,108 @@ func Health(next http.Handler) http.Handler {
 	})
 }
 
-func (p *Plugin) AcceptType(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/" {
-			accept := r.Header.Get(acceptHeader)
-			if len(accept) > 0 && !currentMediaType.Is(accept) {
-				if err := checkMediaTypeSet(); err != nil {
-					w.WriteHeader(http.StatusNotAcceptable)
-					fmt.Fprint(w, err.Error())
-					requestLog(r).WithField(logFieldError, err).Info("accept header check failed")
-					return
-				}
-				w.Header().Set(contentTypeHeader, contentTypePlaintext)
-				w.WriteHeader(http.StatusUnsupportedMediaType)
-				err := fmt.Errorf("only allows media type '%s' as accept header ", currentMediaType)
-				fmt.Fprint(w, err.Error())
-				requestLog(r).WithField(logFieldError, err).Info("accept header check failed")
-				return
-			}
-		}
-		next.ServeHTTP(w, r)
-	})
+func (p *Plugin) contentTypeHeaderCheck(w http.ResponseWriter, r *http.Request) error {
+	return p.headerCheck(true, w, r)
 }
 
-func (p *Plugin) ContentType(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/" {
-			contentType := r.Header.Get(contentTypeHeader)
-			if len(contentType) > 0 && !currentMediaType.Is(contentType) {
-				if err := checkMediaTypeSet(); err != nil {
-					w.WriteHeader(http.StatusNotAcceptable)
-					fmt.Fprint(w, err.Error())
-					requestLog(r).WithField(logFieldError, err).Info("content type header check failed")
-					return
-				}
-				w.Header().Set(contentTypeHeader, contentTypePlaintext)
-				w.WriteHeader(http.StatusUnsupportedMediaType)
-				err := fmt.Errorf("only allows media type '%s' as content-type", currentMediaType)
-				fmt.Fprint(w, err.Error())
-				requestLog(r).WithField(logFieldError, err).Info("content type header check failed")
-				return
-			}
-		}
-		next.ServeHTTP(w, r)
-	})
+func (p *Plugin) acceptHeaderCheck(w http.ResponseWriter, r *http.Request) error {
+	return p.headerCheck(false, w, r)
 }
 
-// Negotiate get request endpoint handler
-func (p *Plugin) Negotiate(w http.ResponseWriter, r *http.Request) {
-	if p.hasAcceptHeader(w, r) {
-		err := checkAndSetMediaTypeHeaderValue(r.Header.Get(acceptHeader))
-		if err != nil {
-			w.Header().Set(contentTypeHeader, contentTypePlaintext)
-			w.WriteHeader(http.StatusUnsupportedMediaType)
-			fmt.Fprint(w, err.Error())
-			requestLog(r).Info(err.Error())
-			return
-		}
-		w.Header().Set(varyHeader, contentTypeHeader)
-		w.Header().Set(contentTypeHeader, string(currentMediaType))
-		requestLog(r).Debugf("negotiating media type, returning media type: '%s'", currentMediaType)
-		w.WriteHeader(http.StatusOK)
+func (p *Plugin) headerCheck(isContentType bool, w http.ResponseWriter, r *http.Request) error {
+	var header string
+	if isContentType {
+		header = r.Header.Get(contentTypeHeader)
+	} else {
+		header = r.Header.Get(acceptHeader)
 	}
+	if len(header) == 0 {
+		w.Header().Set(contentTypeHeader, contentTypePlaintext)
+		w.WriteHeader(http.StatusNotAcceptable)
+		msg := "client must provide "
+		if isContentType {
+			msg += "a content type"
+		} else {
+			msg += "an accept header"
+		}
+		err := fmt.Errorf(msg)
+		_, writeErr := fmt.Fprint(w, err.Error())
+		if writeErr != nil {
+			requestLog(r).WithField(logFieldError, writeErr).Fatalf("error writing error message to response writer")
+		}
+		return err
+	}
+	// as we support only one media type version, we can ignore the returned value
+	if _, err := checkAndGetMediaTypeHeaderValue(header); err != nil {
+		w.Header().Set(contentTypeHeader, contentTypePlaintext)
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		msg := "client must provide a valid versioned media type in the "
+		if isContentType {
+			msg += "content type"
+		} else {
+			msg += "accept header"
+		}
+		err := fmt.Errorf(msg+": %s", err.Error())
+		_, writeErr := fmt.Fprint(w, err.Error())
+		if writeErr != nil {
+			requestLog(r).WithField(logFieldError, writeErr).Fatalf("error writing error message to response writer")
+		}
+		return err
+	}
+	return nil
 }
 
 // Records get request endpoint handler
 func (p *Plugin) Records(w http.ResponseWriter, r *http.Request) {
-	if p.hasAcceptHeader(w, r) {
-		requestLog(r).Debug("requesting records")
-		ctx := r.Context()
-		records, err := p.provider.Records(ctx)
-		if err != nil {
-			requestLog(r).WithField(logFieldError, err).Error("error getting records")
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set(contentTypeHeader, string(currentMediaType))
-		w.WriteHeader(http.StatusOK)
-		requestLog(r).Debugf("returning records count: %d", len(records))
-		err = json.NewEncoder(w).Encode(records)
-		if err != nil {
-			requestLog(r).WithField(logFieldError, err).Error("error encoding records")
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
+	if err := p.acceptHeaderCheck(w, r); err != nil {
+		requestLog(r).WithField(logFieldError, err).Error("accept header check failed")
+		return
+	}
+	requestLog(r).Debug("requesting records")
+	ctx := r.Context()
+	records, err := p.provider.Records(ctx)
+	if err != nil {
+		requestLog(r).WithField(logFieldError, err).Error("error getting records")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	requestLog(r).Debugf("returning records count: %d", len(records))
+	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
+	w.Header().Set(varyHeader, contentTypeHeader)
+	err = json.NewEncoder(w).Encode(records)
+	if err != nil {
+		requestLog(r).WithField(logFieldError, err).Error("error encoding records")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 }
 
 // ApplyChanges get request endpoint handler
 func (p *Plugin) ApplyChanges(w http.ResponseWriter, r *http.Request) {
-	if p.hasContentHeader(w, r) {
-		var changes plan.Changes
-		ctx := r.Context()
-		if err := json.NewDecoder(r.Body).Decode(&changes); err != nil {
-			w.Header().Set(contentTypeHeader, contentTypePlaintext)
-			w.WriteHeader(http.StatusBadRequest)
-			errMsg := fmt.Sprintf("error decoding changes: %s", err.Error())
-			fmt.Fprint(w, errMsg)
-			requestLog(r).WithField(logFieldError, err).Info(errMsg)
-			return
-		}
-		requestLog(r).Debugf("requesting apply changes, create: %d , updateOld: %d, updateNew: %d, delete: %d",
-			len(changes.Create), len(changes.UpdateOld), len(changes.UpdateNew), len(changes.Delete))
-		err := p.provider.ApplyChanges(ctx, &changes)
-		if err != nil {
-			w.Header().Set(contentTypeHeader, contentTypePlaintext)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
+	if err := p.contentTypeHeaderCheck(w, r); err != nil {
+		requestLog(r).WithField(logFieldError, err).Error("content type header check failed")
+		return
 	}
+	var changes plan.Changes
+	ctx := r.Context()
+	if err := json.NewDecoder(r.Body).Decode(&changes); err != nil {
+		w.Header().Set(contentTypeHeader, contentTypePlaintext)
+		w.WriteHeader(http.StatusBadRequest)
+		errMsg := fmt.Sprintf("error decoding changes: %s", err.Error())
+		if _, writeError := fmt.Fprint(w, errMsg); writeError != nil {
+			requestLog(r).WithField(logFieldError, writeError).Fatalf("error writing error message to response writer")
+		}
+		requestLog(r).WithField(logFieldError, err).Info(errMsg)
+		return
+	}
+	requestLog(r).Debugf("requesting apply changes, create: %d , updateOld: %d, updateNew: %d, delete: %d",
+		len(changes.Create), len(changes.UpdateOld), len(changes.UpdateNew), len(changes.Delete))
+	if err := p.provider.ApplyChanges(ctx, &changes); err != nil {
+		w.Header().Set(contentTypeHeader, contentTypePlaintext)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 // PropertyValuesEqualsRequest holds params for property values equals request
@@ -233,47 +193,72 @@ type PropertiesValuesEqualsResponse struct {
 
 // PropertyValuesEquals get request endpoint handler
 func (p *Plugin) PropertyValuesEquals(w http.ResponseWriter, r *http.Request) {
-	if p.hasContentHeader(w, r) && p.hasAcceptHeader(w, r) {
-		pve := PropertyValuesEqualsRequest{}
-		if err := json.NewDecoder(r.Body).Decode(&pve); err != nil {
-			w.Header().Set(contentTypeHeader, contentTypePlaintext)
-			w.WriteHeader(http.StatusBadRequest)
-			errMessage := fmt.Sprintf("failed to decode request body: %v", err)
-			fmt.Fprint(w, errMessage)
-			requestLog(r).WithField(logFieldError, err).Info(errMessage)
-			return
+	if err := p.contentTypeHeaderCheck(w, r); err != nil {
+		requestLog(r).WithField(logFieldError, err).Error("content type header check failed")
+		return
+	}
+	if err := p.acceptHeaderCheck(w, r); err != nil {
+		requestLog(r).WithField(logFieldError, err).Error("accept header check failed")
+		return
+	}
+
+	pve := PropertyValuesEqualsRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&pve); err != nil {
+		w.Header().Set(contentTypeHeader, contentTypePlaintext)
+		w.WriteHeader(http.StatusBadRequest)
+		errMessage := fmt.Sprintf("failed to decode request body: %v", err)
+
+		if _, writeError := fmt.Fprint(w, errMessage); writeError != nil {
+			requestLog(r).WithField(logFieldError, writeError).Fatalf("error writing error message to response writer")
 		}
-		requestLog(r).Debugf("requesting property values equals, name: %s, previous: %s , current: %s",
-			pve.Name, pve.Previous, pve.Current)
-		valuesEqual := p.provider.PropertyValuesEqual(pve.Name, pve.Previous, pve.Current)
-		resp := PropertiesValuesEqualsResponse{
-			Equals: valuesEqual,
-		}
-		out, _ := json.Marshal(&resp)
-		requestLog(r).Debugf("return property values equals response equals: %v", valuesEqual)
-		w.Header().Set(contentTypeHeader, string(currentMediaType))
-		fmt.Fprint(w, string(out))
+		requestLog(r).WithField(logFieldError, err).Info(errMessage)
+		return
+	}
+	requestLog(r).Debugf("requesting property values equals, name: %s, previous: %s , current: %s",
+		pve.Name, pve.Previous, pve.Current)
+	valuesEqual := p.provider.PropertyValuesEqual(pve.Name, pve.Previous, pve.Current)
+	resp := PropertiesValuesEqualsResponse{
+		Equals: valuesEqual,
+	}
+	out, _ := json.Marshal(&resp)
+	requestLog(r).Debugf("return property values equals response equals: %v", valuesEqual)
+	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
+	w.Header().Set(varyHeader, contentTypeHeader)
+	if _, writeError := fmt.Fprint(w, string(out)); writeError != nil {
+		requestLog(r).WithField(logFieldError, writeError).Fatalf("error writing response")
 	}
 }
 
 // AdjustEndpoints get request endpoint handler
 func (p *Plugin) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
-	if p.hasContentHeader(w, r) && p.hasAcceptHeader(w, r) {
-		var pve []*endpoint.Endpoint
-		if err := json.NewDecoder(r.Body).Decode(&pve); err != nil {
-			w.Header().Set(contentTypeHeader, contentTypePlaintext)
-			w.WriteHeader(http.StatusBadRequest)
-			errMessage := fmt.Sprintf("failed to decode request body: %v", err)
-			log.Infof(errMessage+" , request method: %s, request path: %s", r.Method, r.URL.Path)
-			fmt.Fprint(w, errMessage)
-			return
+	if err := p.contentTypeHeaderCheck(w, r); err != nil {
+		log.Errorf("content type header check failed, request method: %s, request path: %s", r.Method, r.URL.Path)
+		return
+	}
+	if err := p.acceptHeaderCheck(w, r); err != nil {
+		log.Errorf("accept header check failed, request method: %s, request path: %s", r.Method, r.URL.Path)
+		return
+	}
+
+	var pve []*endpoint.Endpoint
+	if err := json.NewDecoder(r.Body).Decode(&pve); err != nil {
+		w.Header().Set(contentTypeHeader, contentTypePlaintext)
+		w.WriteHeader(http.StatusBadRequest)
+		errMessage := fmt.Sprintf("failed to decode request body: %v", err)
+		log.Infof(errMessage+" , request method: %s, request path: %s", r.Method, r.URL.Path)
+		if _, writeError := fmt.Fprint(w, errMessage); writeError != nil {
+			requestLog(r).WithField(logFieldError, writeError).Fatalf("error writing error message to response writer")
 		}
-		log.Debugf("requesting adjust endpoints count: %d", len(pve))
-		pve = p.provider.AdjustEndpoints(pve)
-		out, _ := json.Marshal(&pve)
-		log.Debugf("return adjust endpoints response, resultEndpointCount: %d", len(pve))
-		w.Header().Set(contentTypeHeader, string(currentMediaType))
-		fmt.Fprint(w, string(out))
+		return
+	}
+	log.Debugf("requesting adjust endpoints count: %d", len(pve))
+	pve = p.provider.AdjustEndpoints(pve)
+	out, _ := json.Marshal(&pve)
+	log.Debugf("return adjust endpoints response, resultEndpointCount: %d", len(pve))
+	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
+	w.Header().Set(varyHeader, contentTypeHeader)
+	if _, writeError := fmt.Fprint(w, string(out)); writeError != nil {
+		requestLog(r).WithField(logFieldError, writeError).Fatalf("error writing response")
 	}
 }
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -126,7 +126,7 @@ func (p *Plugin) headerCheck(isContentType bool, w http.ResponseWriter, r *http.
 	return nil
 }
 
-// Records get request endpoint handler
+// Records handles the get request for records
 func (p *Plugin) Records(w http.ResponseWriter, r *http.Request) {
 	if err := p.acceptHeaderCheck(w, r); err != nil {
 		requestLog(r).WithField(logFieldError, err).Error("accept header check failed")
@@ -151,7 +151,7 @@ func (p *Plugin) Records(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// ApplyChanges get request endpoint handler
+// ApplyChanges handles the post request for record changes
 func (p *Plugin) ApplyChanges(w http.ResponseWriter, r *http.Request) {
 	if err := p.contentTypeHeaderCheck(w, r); err != nil {
 		requestLog(r).WithField(logFieldError, err).Error("content type header check failed")
@@ -191,7 +191,7 @@ type PropertiesValuesEqualsResponse struct {
 	Equals bool `json:"equals"`
 }
 
-// PropertyValuesEquals get request endpoint handler
+// PropertyValuesEquals handles the post request for property values equals
 func (p *Plugin) PropertyValuesEquals(w http.ResponseWriter, r *http.Request) {
 	if err := p.contentTypeHeaderCheck(w, r); err != nil {
 		requestLog(r).WithField(logFieldError, err).Error("content type header check failed")
@@ -229,7 +229,7 @@ func (p *Plugin) PropertyValuesEquals(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// AdjustEndpoints get request endpoint handler
+// AdjustEndpoints handles the post request for adjusting endpoints
 func (p *Plugin) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 	if err := p.contentTypeHeaderCheck(w, r); err != nil {
 		log.Errorf("content type header check failed, request method: %s, request path: %s", r.Method, r.URL.Path)


### PR DESCRIPTION
Implements  API content negotiation regarding the spec of the [Zalando API guidelines](http://opensource.zalando.com/restful-api-guidelines/#114)

See [discussions in the PR of external-dns here](https://github.com/kubernetes-sigs/external-dns/pull/3063#discussion_r1219352975) and [here](
https://github.com/kubernetes-sigs/external-dns/pull/3063/files/bdc19db88b1a9793cc2e2473e1c932673709112d#r1219518425)

In the [`server_test.go`](https://github.com/ionos-cloud/external-dns-ionos-plugin/blob/content-negotiation/cmd/plugin/init/server/server_test.go) you can see the exact server behavior regarding version headers.
